### PR TITLE
Add custom common bucket functionality

### DIFF
--- a/rating-interface/codegen.toml
+++ b/rating-interface/codegen.toml
@@ -13,12 +13,6 @@ url = "https://wasmcloud.github.io/interfaces/idl/org.wasmcloud"
 files = [ "wasmcloud-core.smithy", "wasmcloud-model.smithy" ]
 
 
-[html]
-output_dir = "html"
-
-[html.parameters]
-minified = true
-
 [rust]
 
 # top-level output directory for rust files.

--- a/rating-interface/rust/src/custom.rs
+++ b/rating-interface/rust/src/custom.rs
@@ -1,0 +1,39 @@
+use crate::Bucket;
+use wasmbus_rpc::actor::prelude::{RpcError, RpcResult};
+
+impl Bucket {
+    /// Create a new bucket by deserializing a JSON string
+    pub fn try_from_str(bucket_json_str: &str) -> RpcResult<Bucket> {
+        serde_json::from_str(bucket_json_str).map_err(|e| RpcError::Deser(e.to_string()))
+    }
+
+    /// Serialize the bucket to a JSON string
+    pub fn serialize(&self) -> RpcResult<String> {
+        serde_json::to_string(self).map_err(|e| RpcError::Ser(e.to_string()))
+    }
+
+    /// Get the bucket characteristic count
+    pub fn characteristic_count(&self) -> u16 {
+        self.bucket_characteristic.count
+    }
+
+    /// Clear the bucket characteristic count
+    pub fn clear_characteristic_count(&mut self) {
+        self.bucket_characteristic.count = 0;
+    }
+
+    /// Increment the bucket characteristic count
+    pub fn increment_characteristic_count(&mut self) {
+        self.bucket_characteristic.count += 1;
+    }
+
+    /// Decrement the bucket characteristic count
+    pub fn decrement_characteristic_count(&mut self) {
+        self.bucket_characteristic.count -= 1;
+    }
+
+    /// Set the bucket characteristic count
+    pub fn set_characteristic_count(&mut self, count: u16) {
+        self.bucket_characteristic.count = count;
+    }
+}

--- a/rating-interface/rust/src/lib.rs
+++ b/rating-interface/rust/src/lib.rs
@@ -1,7 +1,7 @@
+mod custom;
 mod interface;
 mod mock;
 
+pub use custom::*;
 pub use interface::*;
 pub use mock::*;
-
-


### PR DESCRIPTION
This PR adds additional implementations for the `Bucket` struct which allow for easy accessing and modifying of data on a `Bucket` struct. It also updates the two rating agents that use this struct to use the methods, for demonstration purposes.

Two of the more useful functions here are `try_from_str` and `serialize` which provide easy ways to deserialize and serialize while wrapping the error with an `RpcError` so you can easily try unwrap with `?`.

This PR is set to merge into #23 to avoid too many changes. Separate from this PR I would recommend running `cargo fmt` in order to format the Rust code in an idiomatic way.